### PR TITLE
Update README.md changed qb-target bone

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,7 @@ Config.TargetBones = {
 
 	["bones"] = {
         bones = {
-            'boot', 
-            'rudder', 
-            'rudder2', 
-            'petrolcap', 
-            'petroltank', 
-            'petroltank_l', 
-            'petroltank_r',
+            'wheel_lr',
         },
         options = {
       {


### PR DESCRIPTION
Not all GTA vehicle were able to be refuelled. Changed it to this and it seems to have solved the problem including any custom vehicle