### PR TITLE
qb-target canInteract addition

### DIFF
--- a/source/fuel_client.lua
+++ b/source/fuel_client.lua
@@ -356,6 +356,13 @@ CreateThread(function()
 			event = "lj-fuel:client:SendMenuToServer",
 			icon = "fas fa-gas-pump",
 			label = "Refuel Vehicle",
+			canInteract = function()
+				if HasPedGotWeapon(PlayerPedId(), 883325847) or inGasStation then
+					return true
+				else
+					return false
+				end
+			end,
 		}
 	},
 		distance = 1.5,


### PR DESCRIPTION
Adding canInteract to only show the "Refuel Vehicle" label when the player is in GasStation zone or has the petrol can on them.