### PR TITLE
Fix for Jerry Can one time use

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,22 @@ end)
 ```
 (removes infinite jerry can and fire extinguisher ammo)
 ## inventory
-* Remove the following from your client side inventory lua file.
+* Replace the following from your client side inventory lua file.
 ```lua
     if weaponName == "weapon_petrolcan" or weaponName == "weapon_fireextinguisher" then
         ammo = 4000
     end
 ```
-(removes jerry can and fire extinguisher refull when pulled from inventory)
+With the following:
+```lua
+    if weaponName == "weapon_fireextinguisher" then
+        ammo = 4000
+    end
+    if weaponName == "weapon_petrolcan" then
+        ammo = math.floor(ammo * 45)
+    end
+```
+(removes jerry can refull when pulled from inventory)
 
 # Key Features
 * NoPixel style animation for refueling

--- a/client/client.lua
+++ b/client/client.lua
@@ -286,8 +286,6 @@ RegisterNetEvent('lj-fuel:client:RefuelVehicle', function(refillCost)
 				disableMouse = false,
 				disableCombat = true,
 				}, {}, {}, {}, function() -- Done
-				SetFuel(vehicle, 100)
-				SetPedAmmo(ped, 883325847, 0)
 				QBCore.Functions.TriggerCallback('lj-fuel:server:fuelCan', function(itemData)
 					requiredFuel = math.floor(100 - CurFuel)
 					jerryCanFuel = math.floor(GetAmmoInPedWeapon(ped, 883325847) / 45)

--- a/client/client.lua
+++ b/client/client.lua
@@ -289,7 +289,20 @@ RegisterNetEvent('lj-fuel:client:RefuelVehicle', function(refillCost)
 				SetFuel(vehicle, 100)
 				SetPedAmmo(ped, 883325847, 0)
 				QBCore.Functions.TriggerCallback('lj-fuel:server:fuelCan', function(itemData)
-					TriggerServerEvent("weapons:server:AddWeaponAmmo", itemData, 0)
+					requiredFuel = math.floor(100 - CurFuel)
+					jerryCanFuel = math.floor(GetAmmoInPedWeapon(ped, 883325847) / 45)
+					if jerryCanFuel >= requiredFuel then
+						fuelAdd = math.floor(CurFuel + requiredFuel)
+						fuelRemove = math.floor((jerryCanFuel - requiredFuel) * 45)
+						jerryAmmo = math.floor(jerryCanFuel - requiredFuel)
+					else 
+						fuelAdd = math.floor(CurFuel + jerryCanFuel)
+						fuelRemove = 0
+						jerryAmmo = 0
+					end
+					SetFuel(vehicle, fuelAdd)
+					TriggerServerEvent("weapons:server:AddWeaponAmmo", itemData, jerryAmmo)
+					SetPedAmmo(ped, 883325847, fuelRemove)
 				end)
 				PlaySound(-1, "5_SEC_WARNING", "HUD_MINI_GAME_SOUNDSET", 0, 0, 1)
 				StopAnimTask(ped, "weapon@w_sp_jerrycan", "fire", 3.0, 3.0, -1, 2, 0, 0, 0, 0)


### PR DESCRIPTION
**Pull Request Description**

This PR allows Jerry Cans to hold a full tank of gas and use only what is required to full the vehicles tank, leaving the remaining amount to fuel the vehicle again later.

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our contributing document and Code of Conduct? Yes
* [x] Have you checked to ensure there aren't other open for the same update/change? Yes
* [x] Have you built and tested the `resource` in-game after the relevant change? Yes
